### PR TITLE
解决使用bert时当训练语料量恰好为batch_size的n+1倍时训练报错的问题。

### DIFF
--- a/rasa_nlu_gao/featurizers/bert_vectors_featurizer.py
+++ b/rasa_nlu_gao/featurizers/bert_vectors_featurizer.py
@@ -85,8 +85,13 @@ class BertVectorsFeaturizer(Featurizer):
             X = np.array(tokens_text)
 
             for i, example in enumerate(examples):
-                example.set(
-                    "text_features", self._combine_with_existing_text_features(example, X[i]))
+                if len(examples) > 1:
+                    example.set(
+                        "text_features", self._combine_with_existing_text_features(example, X[i]))
+                else:
+                    example.set(
+                        "text_features", self._combine_with_existing_text_features(example, X))
+
 
     def process(self, message, **kwargs):
         # type: (Message, **Any) -> None


### PR DESCRIPTION
当只有一条数据取bert向量时，结果会降低一维导致该报错，做了一个if判断，当只有一条数据时直接使用X而不再使用X[i]。